### PR TITLE
Fix improper closure of PR #6

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -195,7 +195,7 @@ steps:
         left: '%payload.pull_request.merged%'
       - type: createIssue
         action_id: new_issue
-        title: Create a list
+        title: Create some lists
         body: 08-create-list.md
       - type: respond
         with: next.md
@@ -226,7 +226,7 @@ steps:
         required: false
         else:
           type: closeIssue
-          issue: Create a list
+          issue: Create some lists
       - type: getFileContents
         filename: index.html
         action_id: index_file


### PR DESCRIPTION
As reported in https://github.com/github/learning-lab/issues/575, there appears to be some behavior in which the bot is closing a PR prematurely. 

I'm not 100% sure, but I think this is because the issue title is named the same as the step title. 

https://github.com/githubtraining/intro-to-html/blob/6d18128db819f21799cef76a3cafafe95b1b37a2/config.yml#L205

https://github.com/githubtraining/intro-to-html/blob/6d18128db819f21799cef76a3cafafe95b1b37a2/config.yml#L227-L229

This PR changes the issue title so that both the step and issue title are different. In [my tests](https://github.com/hectorsector/intro-html/pull/6), this seems to not close out the incorrect PR, which is the desired behavior. 

I'm leaving the original bug report open because this appears to be a bug with Learning Lab, but this PR should fix the issue that's happening in the meantime.