### PR TITLE
CSS file name doesn't match template

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -301,7 +301,7 @@ steps:
         filename: index.html
         action_id: index
       - type: gate
-        left: '/<link rel="stylesheet" href="styles.css">/'
+        left: '/<link rel="stylesheet" href="style.css">/'
         operator: test
         right: '%actions.index%'
         else:


### PR DESCRIPTION
The template repo uses `style.css`, so this didn't work when I ran through it until I updated the file name in my repo. This PR updates the gate to use `style.css` to match what's in the template repo. You can see the failure here: https://github.com/tcbyrd/intro-html/pull/7#issuecomment-409407072

An additional note that might be harder to fix: the bot said it was successful when I changed the file name to what it expected, but then the styles weren't actually loading on the page.