### PR TITLE
Add required false fields

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -234,10 +234,12 @@ steps:
         html: '%actions.index_file%'
         tag: ul
         action_id: contains_ul
+        required: false
       - type: htmlContainsTag
         html: '%actions.index_file%'
         tag: ol
         action_id: contains_ol
+        required: false
       - type: gate
         gates:
           - left: '%actions.contains_ul%'
@@ -262,6 +264,7 @@ steps:
         html: '%actions.index_file%'
         tag: a
         action_id: contains_a
+        required: false
       - type: gate
         left: '%actions.contains_a%'
         else:


### PR DESCRIPTION
Due to a change in how we treat optional actions in a step, a bug was introduced where both an unordered list `<ul>` and an ordered list `<ol>` were needed to pass the `Add a list` step. Only one of these should actually be needed.

To resolve this, we added `required: false` fields to actions that we check later with a `gate` - that way we can better control the flow of incorrect or correct submissions.

Fixes #13 

h/t @ppremk for pairing 🎉 