### PR TITLE
Replace "styles.css" with "style.css"

### DIFF
--- a/responses/11-style-fail.md
+++ b/responses/11-style-fail.md
@@ -1,6 +1,6 @@
 Uh oh, I didn't find the <link> tag inside the <head>! Here are some troubleshooting steps:
 
-1. Check your spelling. We're checking specifically for the following: `<link rel="stylesheet" href="styles.css">`.
+1. Check your spelling. We're checking specifically for the following: `<link rel="stylesheet" href="style.css">`.
 2. This must be after the opening `<head>` tag, and before the closing `</head>` tag.
 
 Let's try again!
@@ -9,6 +9,6 @@ Let's try again!
 
 1. Click on **Files Changed**.
 1. Click on the :pencil: to edit the file.
-1. Add the link tag inside the `<head>` section of the index: `<link rel="stylesheet" href="styles.css">`
+1. Add the link tag inside the `<head>` section of the index: `<link rel="stylesheet" href="style.css">`
 1. In the _Commit changes_ section, enter a commit message that describes what you've done.
 1. Click on **Commit changes**.


### PR DESCRIPTION
The error message if a user doesn't do something quite right while adding CSS currently says "styles.css" instead of "style.css". This was reported [via halp](https://halp.githubapp.com/inboxes/learning-lab/discussions/f054ff903c3011e990a4f4f73cb79982).

@hectorsector  Please merge if this is ok 👍 