### PR TITLE
Add gate in intro to html course for actual list items

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -280,7 +280,7 @@ steps:
         html: "%actions.index_file%"
         tag: li
         action_id: contains_li
-        required: true
+        required: false
       - type: gate
         gates:
           - left: "%actions.contains_li%"

--- a/config.yml
+++ b/config.yml
@@ -276,6 +276,18 @@ steps:
           type: createReview
           body: 08e-list.md
           event: REQUEST_CHANGES
+      - type: htmlContainsTag
+        html: "%actions.index_file%"
+        tag: li
+        action_id: contains_li
+        required: true
+      - type: gate
+        gates:
+          - left: "%actions.contains_li%"
+        else:
+          type: createReview
+          body: 08e-list.md
+          event: REQUEST_CHANGES
       - type: createPullRequestComment
         body: 09-add-links.md
         file: index.html


### PR DESCRIPTION
This pull request adds a gate that checks for `li` within the step where users are asked to write a list. This closes #7. 

I'm going to test this myself, and will reach out when it's ready for review.